### PR TITLE
capture.sh: add vp9 threading

### DIFF
--- a/src/capture.sh
+++ b/src/capture.sh
@@ -13,7 +13,10 @@ fps="15"
 raw_video="-vf fps=$fps -c:v utvideo -f nut"
 raw_video_container=".nut"
 
-webm_video="-pix_fmt yuv420p -c:v libvpx-vp9 -crf 25 -b:v 0 -f webm"
+# libvpx-vp9 doesn't implement frame-level parallelism, so the maximum number of
+# threads is proportional to the size of each frame
+# https://stackoverflow.com/questions/41372045/vp9-encoding-limited-to-4-threads
+webm_video="-pix_fmt yuv420p -c:v libvpx-vp9 -crf 25 -b:v 0 -f webm -tile-columns 6 -frame-parallel 1 -threads 8"
 
 tmpdir="/var/tmp"
 
@@ -66,7 +69,7 @@ countdown () {
 capture () {
   local tmpfile output
 
-  tmpfile=$(mktemp -p"$tmpdir" --suffix "$raw_video_suffix")
+  tmpfile=$(mktemp -p"$tmpdir" --suffix "$raw_video_container")
   output="$2"
 
   if [ -z "$2" ]; then


### PR DESCRIPTION
This mostly helps with videos with larger frame sizes (>=1080p).

In my testing, on an `Intel(R) Core(TM) i7-4900MQ CPU @ 2.80GHz` (4 core 8 thread):

video:
```
2848x1603, 159 frames, 10.53 seconds
```

stats:

| commit | encode time | size | sha1sum |
| ---- | ---- | ---- | ---- |
| d1a2812 (current) | 503.68s (1x) | 8.26 MB | 0dc17babf |
| 9773813 (this pr) | 198.36s (2.5x) | 8.26 MB | 0dc17babf |

Interpretation: for these test conditions expected to accurately reflect actual capture usage, this produces byte-exact identical output 2.5x faster than the previous configuration.